### PR TITLE
Add getTimezoneOffset

### DIFF
--- a/src/Effect/Now.js
+++ b/src/Effect/Now.js
@@ -4,6 +4,7 @@ exports.now = function () {
   return Date.now();
 };
 
-exports.getTimezoneOffset = function (date) {
-  return date.getTimezoneOffset()
+exports.getTimezoneOffset = function () {
+  var n = new Date(Date.now());
+  return n.getTimezoneOffset();
 };

--- a/src/Effect/Now.js
+++ b/src/Effect/Now.js
@@ -3,3 +3,7 @@
 exports.now = function () {
   return Date.now();
 };
+
+exports.getTimezoneOffset = function (date) {
+  return date.getTimezoneOffset()
+};

--- a/src/Effect/Now.purs
+++ b/src/Effect/Now.purs
@@ -9,7 +9,7 @@ module Effect.Now
 import Prelude
 
 import Data.DateTime (Date, DateTime, Time, date, time)
-import Data.Time.Duration (Minute)
+import Data.Time.Duration (Minutes)
 import Data.DateTime.Instant (Instant, toDateTime)
 import Effect (Effect)
 
@@ -31,4 +31,4 @@ nowTime :: Effect Time
 nowTime = time <<< toDateTime <$> now
 
 -- | Gets the time zone difference, in minutes, from current local (host system settings) to UTC using `now`.
-foreign import getTimezoneOffset :: Effect Minute
+foreign import getTimezoneOffset :: Effect Minutes

--- a/src/Effect/Now.purs
+++ b/src/Effect/Now.purs
@@ -30,5 +30,5 @@ nowDate = date <<< toDateTime <$> now
 nowTime :: Effect Time
 nowTime = time <<< toDateTime <$> now
 
--- | Gets the time zone difference, in minutes, from current locale (host system settings) to UTC
-foreign import getTimezoneOffset :: Instant -> Effect Minute
+-- | Gets the time zone difference, in minutes, from current local (host system settings) to UTC using `now`.
+foreign import getTimezoneOffset :: Effect Minute

--- a/src/Effect/Now.purs
+++ b/src/Effect/Now.purs
@@ -3,11 +3,13 @@ module Effect.Now
   , nowDateTime
   , nowDate
   , nowTime
+  , getTimezoneOffset
   ) where
 
 import Prelude
 
 import Data.DateTime (Date, DateTime, Time, date, time)
+import Data.Time.Component (Minute)
 import Data.DateTime.Instant (Instant, toDateTime)
 import Effect (Effect)
 
@@ -27,3 +29,6 @@ nowDate = date <<< toDateTime <$> now
 -- | Gets the time according to the current machine’s clock.
 nowTime :: Effect Time
 nowTime = time <<< toDateTime <$> now
+
+-- | Gets the time zone difference, in minutes, from current locale (host system settings) to UTC
+foreign import getTimezoneOffset :: Instant -> Effect Minute

--- a/src/Effect/Now.purs
+++ b/src/Effect/Now.purs
@@ -9,7 +9,7 @@ module Effect.Now
 import Prelude
 
 import Data.DateTime (Date, DateTime, Time, date, time)
-import Data.Time.Component (Minute)
+import Data.Time.Duration (Minute)
 import Data.DateTime.Instant (Instant, toDateTime)
 import Effect (Effect)
 


### PR DESCRIPTION
## What does this pull request do?

add function getTimezoneOffset and fixes #8 

## Where should the reviewer start?

`src/Effect/Now.js`

## How should this be manually tested?

## Other Notes:

Being this is purescript-now I used:
```Javascript
exports.getTimezoneOffset = function () {
  var n = new Date(Date.now());
  return n.getTimezoneOffset();
};
```
repl output from UK based local:

```bash
> getTimezoneOffset
(Minute -60)
```
Fell like if we'd want `Date -> Effect Minute` it might need to live in `purescript-datetime`?
