### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#23 by @thomashoneyman)
 - Added tests (#20 by @ntwilson)
 - Added quick start (#22 by @maxdeviant)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -17,28 +17,27 @@ type FailedTestCount = Int
 type Test = StateT FailedTestCount Effect Unit
 
 test :: String -> Effect Unit -> Test
-test name body = 
+test name body =
   try (lift body) >>= case _ of
     Right _ -> log ("✔️  " <> name)
-    Left err -> do 
+    Left err -> do
       log ("❌  " <> name)
       logShow err
       void $ modify (_ + 1)
 
-assertDoesNotThrow :: ∀ a. Effect a -> Effect Unit
+assertDoesNotThrow :: forall a. Effect a -> Effect Unit
 assertDoesNotThrow action = try action >>= case _ of
   Right _ -> pure unit
   Left err -> do throw ("Expected to not throw an exception, but one was thrown.\n" <> show err)
 
-
-timeAdvances :: ∀ time. Show time => Ord time => Effect time -> String -> Test
+timeAdvances :: forall time. Show time => Ord time => Effect time -> String -> Test
 timeAdvances getTime name = test ("time advances with " <> name) do
   startTime <- getTime
   endTime <- getTime
-  assert' (show endTime <> " should be greater than than " <> show startTime) $ endTime >= startTime 
+  assert' (show endTime <> " should be greater than than " <> show startTime) $ endTime >= startTime
 
 canGetTheCurrentTime :: Test
-canGetTheCurrentTime = test "can get the current time" do 
+canGetTheCurrentTime = test "can get the current time" do
   assertDoesNotThrow nowTime
 
 offsetSeemsSensible :: Test
@@ -47,14 +46,13 @@ offsetSeemsSensible = test "UTC offset between -13:00 and +15:00" do
   assert $ between lbound ubound minutes
 
   where
-    lbound = Minutes $ (-13.0) * minPerHour
-    ubound = Minutes $ 15.0 * minPerHour
-    minPerHour = 60.0
-    
+  lbound = Minutes $ (-13.0) * minPerHour
+  ubound = Minutes $ 15.0 * minPerHour
+  minPerHour = 60.0
 
 main :: Effect Unit
 main = do
-  failedTests <- flip execStateT 0 do 
+  failedTests <- flip execStateT 0 do
     timeAdvances now "now"
     timeAdvances nowDate "nowDate"
     canGetTheCurrentTime


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
